### PR TITLE
Add basic plan with £5 per month rate

### DIFF
--- a/src/components/home/Plan.tsx
+++ b/src/components/home/Plan.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export function Plan() {
+  return (
+    <section className="bg-[#2B2C30] section-padding">
+      <div className="max-w-6xl mx-auto text-center">
+        <h2 className="heading text-[#F1EFE8]">Basic Plan</h2>
+        <p className="subheading text-[#F1EFE8]/80 max-w-2xl mx-auto">
+          £5 per month
+        </p>
+        <ul className="list-disc list-inside text-[#F1EFE8] mt-6">
+          <li>Feature 1: AI-powered analytics</li>
+          <li>Feature 2: Interactive displays</li>
+          <li>Feature 3: Gamified rewards</li>
+          <li>Feature 4: Real-time insights</li>
+          <li>Feature 5: Seamless integration</li>
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,11 +5,10 @@ import { Features } from '../components/home/Features';
 import { HowItWorks } from '../components/home/HowItWorks';
 import { WhatWeDeliver } from '../components/home/WhatWeDeliver';
 import { WhyDifferent } from '../components/home/WhyDifferent';
-import { FutureRetail } from '../components/home/FutureRetail';
-import { Testimonials } from '../components/home/Testimonials';
 import { ContactSection } from '../components/home/ContactSection';
 import { Subscribe } from '../components/home/Subscribe';
 import { Cta } from '../components/home/Cta';
+import { Plan } from '../components/home/Plan';
 
 export function Home() {
   useEffect(() => {
@@ -40,8 +39,7 @@ export function Home() {
       <HowItWorks />
       <WhatWeDeliver />
       <WhyDifferent />
-      {/* <FutureRetail /> */}
-      {/* <Testimonials /> */}
+      <Plan />
       <ContactSection />
       <Subscribe />
       <Cta />


### PR DESCRIPTION
Add a new plan with a £5 per month rate and update the home page to include it.

* **New Plan Component**
  - Create `src/components/home/Plan.tsx` to display the £5 per month plan.
  - Include features such as AI-powered analytics, interactive displays, gamified rewards, real-time insights, and seamless integration.

* **Home Page Update**
  - Import the new `Plan` component in `src/pages/Home.tsx`.
  - Add the `Plan` component to the page layout.
  - Remove references to `FutureRetail` and `Testimonials` components.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/WEBXELA/coupit-wx/pull/6?shareId=abd457a2-4579-416f-9ef9-bf59df0162bc).